### PR TITLE
item/:name -> item/search/:name to distinguish from item/:id

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ router.get("/items/post/:postUser", readPostedItems) //posted items
 router.get("/items/claim/:claimUser", readClaimedItems) //claimed items
 
 //search
-router.get("/items/:name", searchItems) //search term in body.
+router.get("/items/search/:name", searchItems) //search term in url
 
 app.use(router);
 app.listen(port, () => console.log(`Listening on port ${port}`));


### PR DESCRIPTION
Bug where item/:name and item/:id used the same syntax. Always used the function for id. Changed item/:name -> item/search/:name.